### PR TITLE
Fix bug where playerIdParam is ignored if ConsentComponent is not absent.

### DIFF
--- a/imports/core/ui/components/NewPlayer.jsx
+++ b/imports/core/ui/components/NewPlayer.jsx
@@ -9,7 +9,6 @@ import Centered from "./Centered.jsx";
 
 const { ConsentComponent } = config;
 import Loading from "./Loading.jsx";
-const { playerIdParam } = Meteor.settings.public;
 
 export default class NewPlayer extends React.Component {
   state = { id: "", consented: false };
@@ -28,6 +27,10 @@ export default class NewPlayer extends React.Component {
   componentWillUnmount() {
     if (this.timeout) {
       clearTimeout(this.timeout);
+    }
+
+    if (!ConsentComponent) {
+      this.playerFromIdParam();
     }
   }
 
@@ -52,7 +55,10 @@ export default class NewPlayer extends React.Component {
 
   handleConsent = () => {
     this.setState({ consented: true });
+    this.playerFromIdParam();
+  };
 
+  playerFromIdParam() {
     const { playerIdParam } = Meteor.settings.public;
 
     if (playerIdParam) {
@@ -71,7 +77,7 @@ export default class NewPlayer extends React.Component {
         });
       }
     }
-  };
+  }
 
   render() {
     const { id, consented, attemptingAutoLogin } = this.state;


### PR DESCRIPTION
This should fix #75.

@joshua-a-becker Thanks for catching this. I changed your proposed implementation a bit. It is not recommended to have data updates run directly in the `render()` function of a React component, as the render code will be called repeatedly over the life of the component. I've simply moved the case where the ConsentComponent is missing to the `componentWillMount()` function, which runs once at the beginning of the component's lifecycle.

I'd appreciate if you could review this change for me and see if it works as you expect.