### PR TITLE
fix: ensure stages are ordered

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/briandowns/spinner v1.18.1
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/cortesi/moddwatch v0.0.0-20210323234936-df014e95c743
-	github.com/empiricaly/tajriba v1.0.0-rc.14
+	github.com/empiricaly/tajriba v1.0.0-rc.15
 	github.com/jpillora/backoff v1.0.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/klauspost/compress v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/briandowns/spinner v1.18.1
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/cortesi/moddwatch v0.0.0-20210323234936-df014e95c743
-	github.com/empiricaly/tajriba v1.0.0-rc.16
+	github.com/empiricaly/tajriba v1.0.0-rc.17
 	github.com/jpillora/backoff v1.0.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/klauspost/compress v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/briandowns/spinner v1.18.1
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/cortesi/moddwatch v0.0.0-20210323234936-df014e95c743
-	github.com/empiricaly/tajriba v1.0.0-rc.15
+	github.com/empiricaly/tajriba v1.0.0-rc.16
 	github.com/jpillora/backoff v1.0.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/klauspost/compress v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/empiricaly/tajriba v1.0.0-rc.14 h1:LQefsYridGMrRPJsTPLi74AI3Sy1gzt9h5
 github.com/empiricaly/tajriba v1.0.0-rc.14/go.mod h1:YjXY+MvdICir57DvGb6DyFkT1sP3DOasxLeAMvXeyB8=
 github.com/empiricaly/tajriba v1.0.0-rc.15 h1:XnXgNFT8lRPV8xNiebcPQf+PcixJp3tQWQKZ3OgrNTQ=
 github.com/empiricaly/tajriba v1.0.0-rc.15/go.mod h1:YjXY+MvdICir57DvGb6DyFkT1sP3DOasxLeAMvXeyB8=
+github.com/empiricaly/tajriba v1.0.0-rc.16 h1:z5SDKItU9LFj6F2rAE8FZhiU0ux9OE4gsZ6FmLdq0To=
+github.com/empiricaly/tajriba v1.0.0-rc.16/go.mod h1:YjXY+MvdICir57DvGb6DyFkT1sP3DOasxLeAMvXeyB8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/empiricaly/tajriba v1.0.0-rc.15 h1:XnXgNFT8lRPV8xNiebcPQf+PcixJp3tQWQ
 github.com/empiricaly/tajriba v1.0.0-rc.15/go.mod h1:YjXY+MvdICir57DvGb6DyFkT1sP3DOasxLeAMvXeyB8=
 github.com/empiricaly/tajriba v1.0.0-rc.16 h1:z5SDKItU9LFj6F2rAE8FZhiU0ux9OE4gsZ6FmLdq0To=
 github.com/empiricaly/tajriba v1.0.0-rc.16/go.mod h1:YjXY+MvdICir57DvGb6DyFkT1sP3DOasxLeAMvXeyB8=
+github.com/empiricaly/tajriba v1.0.0-rc.17 h1:JzSPQlYwCnh8XBOmrE4P7kpvZ6aNYLAJgFxUk/sarzM=
+github.com/empiricaly/tajriba v1.0.0-rc.17/go.mod h1:YjXY+MvdICir57DvGb6DyFkT1sP3DOasxLeAMvXeyB8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/empiricaly/tajriba v1.0.0-rc.13 h1:LGu9EoLYkRSfkOrA4aqa/UYLB1/lzRTPtp
 github.com/empiricaly/tajriba v1.0.0-rc.13/go.mod h1:YjXY+MvdICir57DvGb6DyFkT1sP3DOasxLeAMvXeyB8=
 github.com/empiricaly/tajriba v1.0.0-rc.14 h1:LQefsYridGMrRPJsTPLi74AI3Sy1gzt9h5YJYGQkeBs=
 github.com/empiricaly/tajriba v1.0.0-rc.14/go.mod h1:YjXY+MvdICir57DvGb6DyFkT1sP3DOasxLeAMvXeyB8=
+github.com/empiricaly/tajriba v1.0.0-rc.15 h1:XnXgNFT8lRPV8xNiebcPQf+PcixJp3tQWQKZ3OgrNTQ=
+github.com/empiricaly/tajriba v1.0.0-rc.15/go.mod h1:YjXY+MvdICir57DvGb6DyFkT1sP3DOasxLeAMvXeyB8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/lib/@empirica/core/package-lock.json
+++ b/lib/@empirica/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@empirica/core",
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@empirica/core",
-      "version": "1.0.0-rc.14",
+      "version": "1.0.0-rc.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@empirica/tajriba": "1.0.0-rc.10",

--- a/lib/@empirica/core/package.json
+++ b/lib/@empirica/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@empirica/core",
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.15",
   "description": "Empirica Core",
   "author": "Nicolas Paton <nicolas.paton@gmail.com>",
   "license": "Apache-2.0",

--- a/lib/@empirica/core/src/admin/classic/models.ts
+++ b/lib/@empirica/core/src/admin/classic/models.ts
@@ -381,7 +381,7 @@ export class Game extends BatchOwned {
     const game = this;
     const gameID = game.id;
 
-    const index = (game.get("roundIndex") as number) || 0;
+    const index = (game.get("roundIndex") as number) || -1;
     const roundIndex = index + 1;
     game.set("roundIndex", roundIndex);
 
@@ -750,7 +750,7 @@ export class Round extends GameOwned {
       throw new Error("missing game ID on round");
     }
 
-    const stageIndex = z.number().parse(this.get("stageIndex") || 0) + 1;
+    const stageIndex = z.number().parse(this.get("stageIndex") || -1) + 1;
     this.set("stageIndex", stageIndex);
 
     const [scope, accessors] = scopeConstructor({

--- a/lib/@empirica/core/src/player/react/hooks_test.tsx
+++ b/lib/@empirica/core/src/player/react/hooks_test.tsx
@@ -300,7 +300,7 @@ test.serial("useGlobal", async (t) => {
   });
 
   // Wait for session establishement
-  await nextTick();
+  await nextTick(100);
 
   t.true(result.current instanceof Globals);
 });

--- a/lib/admin-ui/yarn.lock
+++ b/lib/admin-ui/yarn.lock
@@ -26,26 +26,26 @@
     "minimist" "1.2.5"
     "rand-seed" "1.0.1"
 
-"@empirica/core@file:../@empirica/core":
-  "resolved" "file:../@empirica/core"
-  "version" "1.0.0-rc.1"
+"@empirica/core@latest":
+  "integrity" "sha512-oBqo0dN/jDwDWDq0svaTvlsxiMIWTbGkUC3a6fU8Lr0PkpxsVk6/gA6pvVH9qrrlkQwwdox01/M81DDYZI6LWQ=="
+  "resolved" "https://registry.npmjs.org/@empirica/core/-/core-1.0.0-rc.15.tgz"
+  "version" "1.0.0-rc.15"
   dependencies:
-    "@empirica/tajriba" "^1.0.0-rc.1"
+    "@empirica/tajriba" "1.0.0-rc.10"
     "@swc/helpers" "0.4.2"
     "rxjs" "7.5.5"
     "zod" "3.17.3"
 
-"@empirica/tajriba@latest":
-  "integrity" "sha512-gJjTVkcCPj2su9dCdY/mHEq0Unyh/OMxlwOloJn2UdiOHGMtPLzfT55670CmMmSndrlcjUZ1if438LdDRRI4RQ=="
-  "resolved" "https://registry.npmjs.org/@empirica/tajriba/-/tajriba-1.0.0-alpha.4.tgz"
-  "version" "1.0.0-alpha.4"
+"@empirica/tajriba@1.0.0-rc.10", "@empirica/tajriba@latest":
+  "integrity" "sha512-GqPEf4A7phJAx3yPYgZyclRKRzCbtYLCQJplL6USE9x29w+r7ltL1ugBME/au2TL/d5TITQN6c/LyNjeku0IcA=="
+  "resolved" "https://registry.npmjs.org/@empirica/tajriba/-/tajriba-1.0.0-rc.10.tgz"
+  "version" "1.0.0-rc.10"
   dependencies:
     "@urql/core" "2.5.0"
-    "events" "3.3.0"
     "graphql" "16.5.0"
     "graphql-tag" "2.12.6"
     "graphql-ws" "5.9.0"
-    "isomorphic-ws" "4.0.1"
+    "isomorphic-ws" "5.0.0"
     "rxjs" "7.5.5"
     "typed-emitter" "2.1.0"
     "websocket" "1.0.34"
@@ -116,6 +116,13 @@
     "require-relative" "^0.8.7"
     "svelte-hmr" "^0.14.7"
 
+"@swc/helpers@0.4.2":
+  "integrity" "sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw=="
+  "resolved" "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.2.tgz"
+  "version" "0.4.2"
+  dependencies:
+    "tslib" "^2.4.0"
+
 "@types/estree@0.0.39":
   "integrity" "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
   "resolved" "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz"
@@ -163,7 +170,7 @@
     "windicss" "^3.1.8"
 
 "abstract-leveldown@~0.12.0", "abstract-leveldown@~0.12.1":
-  "integrity" "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA="
+  "integrity" "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA= sha512-TOod9d5RDExo6STLMGa+04HGkl+TlMfbDnTyN93/ETJ9DpQ0DaYLqcMZlbXvdc4W3vVo1Qrl+WhSp8zvDsJ+jA=="
   "resolved" "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz"
   "version" "0.12.4"
   dependencies:
@@ -177,7 +184,7 @@
     "color-convert" "^2.0.1"
 
 "any-promise@^1.0.0":
-  "integrity" "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+  "integrity" "sha1-q8av7tzqUugJzcA3au0845Y10X8= sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
   "resolved" "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
   "version" "1.3.0"
 
@@ -234,23 +241,28 @@
   "version" "2.2.0"
 
 "bl@~0.8.1":
-  "integrity" "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4="
+  "integrity" "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4= sha512-pfqikmByp+lifZCS0p6j6KreV6kNU6Apzpm2nKOk+94cZb/jvle55+JxWiByUQ0Wo/+XnDXEy5MxxKMb6r0VIw=="
   "resolved" "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz"
   "version" "0.8.2"
   dependencies:
     "readable-stream" "~1.0.26"
 
-"bn.js@^4.0.0", "bn.js@^4.1.0", "bn.js@^4.11.9":
+"bn.js@^4.0.0":
   "integrity" "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
   "resolved" "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
   "version" "4.12.0"
 
-"bn.js@^5.0.0":
-  "integrity" "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-  "resolved" "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz"
-  "version" "5.2.0"
+"bn.js@^4.1.0":
+  "integrity" "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+  "resolved" "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
+  "version" "4.12.0"
 
-"bn.js@^5.1.1":
+"bn.js@^4.11.9":
+  "integrity" "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+  "resolved" "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
+  "version" "4.12.0"
+
+"bn.js@^5.0.0", "bn.js@^5.1.1":
   "integrity" "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
   "resolved" "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz"
   "version" "5.2.0"
@@ -271,7 +283,7 @@
     "fill-range" "^7.0.1"
 
 "brorand@^1.0.1", "brorand@^1.1.0":
-  "integrity" "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+  "integrity" "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8= sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
   "resolved" "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
   "version" "1.1.0"
 
@@ -307,7 +319,7 @@
     "safe-buffer" "^5.1.2"
 
 "browserify-fs@^1.0.0":
-  "integrity" "sha1-8HWqinKdTRcW0GZiDjhvzBMRqW8="
+  "integrity" "sha1-8HWqinKdTRcW0GZiDjhvzBMRqW8= sha512-8LqHRPuAEKvyTX34R6tsw4bO2ro6j9DmlYBhiYWHRM26Zv2cBw1fJOU0NeUQ0RkXkPn/PFBjhA0dm4AgaBurTg=="
   "resolved" "https://registry.npmjs.org/browserify-fs/-/browserify-fs-1.0.0.tgz"
   "version" "1.0.0"
   dependencies:
@@ -339,7 +351,7 @@
     "safe-buffer" "^5.2.0"
 
 "buffer-es6@^4.9.2":
-  "integrity" "sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ="
+  "integrity" "sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ= sha512-Ibt+oXxhmeYJSsCkODPqNpPmyegefiD8rfutH1NYGhMZQhSp95Rz7haemgnJ6dxa6LT+JLLbtgOMORRluwKktw=="
   "resolved" "https://registry.npmjs.org/buffer-es6/-/buffer-es6-4.9.3.tgz"
   "version" "4.9.3"
 
@@ -349,7 +361,7 @@
   "version" "1.1.2"
 
 "buffer-xor@^1.0.3":
-  "integrity" "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+  "integrity" "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk= sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
   "resolved" "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
   "version" "1.0.3"
 
@@ -397,7 +409,7 @@
     "safe-buffer" "^5.0.1"
 
 "clone@~0.1.9":
-  "integrity" "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU="
+  "integrity" "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU= sha512-IO78I0y6JcSpEPHzK4obKdsL7E7oLdRVDVOLwr2Hkbjsb+Eoz0dxW6tef0WizoKu0gLC4oZSZuEF4U2K6w1WQw=="
   "resolved" "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
   "version" "0.1.19"
 
@@ -419,7 +431,7 @@
   "version" "4.1.1"
 
 "concat-map@0.0.1":
-  "integrity" "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+  "integrity" "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
   "resolved" "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   "version" "0.0.1"
 
@@ -518,7 +530,7 @@
     "ms" "2.1.2"
 
 "deferred-leveldown@~0.2.0":
-  "integrity" "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ="
+  "integrity" "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ= sha512-+WCbb4+ez/SZ77Sdy1iadagFiVzMB89IKOBhglgnUkVxOxRWmmFsz8UDSNWh4Rhq+3wr/vMFlYj+rdEwWUDdng=="
   "resolved" "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz"
   "version" "0.2.0"
   dependencies:
@@ -697,12 +709,12 @@
     "to-regex-range" "^5.0.1"
 
 "foreach@~2.0.1":
-  "integrity" "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+  "integrity" "sha1-C+4AUBiusmDQo6865ljdATbsG5k= sha512-ZBbtRiapkZYLsqoPyZOR+uPfto0GRMNQN1GwzZtZt7iZvPPbDDQV0JF5Hx4o/QFQ5c0vyuoZ98T8RSBbopzWtA=="
   "resolved" "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
   "version" "2.0.5"
 
 "fs.realpath@^1.0.0":
-  "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+  "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8= sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
@@ -717,7 +729,7 @@
   "version" "1.1.1"
 
 "fwd-stream@^1.0.4":
-  "integrity" "sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo="
+  "integrity" "sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo= sha512-q2qaK2B38W07wfPSQDKMiKOD5Nzv2XyuvQlrmh1q0pxyHNanKHq8lwQ6n9zHucAwA5EbzRJKEgds2orn88rYTg=="
   "resolved" "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz"
   "version" "1.0.4"
   dependencies:
@@ -806,7 +818,7 @@
     "minimalistic-assert" "^1.0.1"
 
 "hmac-drbg@^1.0.1":
-  "integrity" "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE="
+  "integrity" "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE= sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="
   "resolved" "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
   "version" "1.0.1"
   dependencies:
@@ -844,12 +856,12 @@
     "resolve-from" "^5.0.0"
 
 "indexof@~0.0.1":
-  "integrity" "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+  "integrity" "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10= sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
   "resolved" "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
   "version" "0.0.1"
 
 "inflight@^1.0.4":
-  "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+  "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk= sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="
   "resolved" "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
   "version" "1.0.6"
   dependencies:
@@ -862,7 +874,7 @@
   "version" "2.0.4"
 
 "inherits@2.0.3":
-  "integrity" "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+  "integrity" "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4= sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
   "resolved" "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
   "version" "2.0.3"
 
@@ -881,7 +893,7 @@
     "has" "^1.0.3"
 
 "is-extglob@^2.1.1":
-  "integrity" "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+  "integrity" "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI= sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
   "resolved" "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   "version" "2.1.1"
 
@@ -898,7 +910,7 @@
   "version" "7.0.0"
 
 "is-object@~0.1.2":
-  "integrity" "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc="
+  "integrity" "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc= sha512-GkfZZlIZtpkFrqyAXPQSRBMsaHAw+CgoKe2HXAkjd/sfoI9+hS8PT4wg2rJxdQyUKr7N2vHJbg7/jQtE5l5vBQ=="
   "resolved" "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz"
   "version" "0.1.2"
 
@@ -913,34 +925,34 @@
   "version" "1.0.0"
 
 "is@~0.2.6":
-  "integrity" "sha1-OzSixI81mXLzUEKEkZOucmS2NWI="
+  "integrity" "sha1-OzSixI81mXLzUEKEkZOucmS2NWI= sha512-ajQCouIvkcSnl2iRdK70Jug9mohIHVX9uKpoWnl115ov0R5mzBvRrXxrnHbsA+8AdwCwc/sfw7HXmd4I5EJBdQ=="
   "resolved" "https://registry.npmjs.org/is/-/is-0.2.7.tgz"
   "version" "0.2.7"
 
 "isarray@~1.0.0":
-  "integrity" "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+  "integrity" "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE= sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
   "resolved" "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
   "version" "1.0.0"
 
 "isarray@0.0.1":
-  "integrity" "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+  "integrity" "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8= sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
   "resolved" "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
   "version" "0.0.1"
 
 "isbuffer@~0.0.0":
-  "integrity" "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s="
+  "integrity" "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s= sha512-xU+NoHp+YtKQkaM2HsQchYn0sltxMxew0HavMfHbjnucBoTSGbw745tL+Z7QBANleWM1eEQMenEpi174mIeS4g=="
   "resolved" "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz"
   "version" "0.0.0"
 
 "isexe@^2.0.0":
-  "integrity" "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+  "integrity" "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA= sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
   "resolved" "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   "version" "2.0.0"
 
-"isomorphic-ws@4.0.1":
-  "integrity" "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
-  "resolved" "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz"
-  "version" "4.0.1"
+"isomorphic-ws@5.0.0":
+  "integrity" "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="
+  "resolved" "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz"
+  "version" "5.0.0"
 
 "jiti@^1.12.5":
   "integrity" "sha512-drQ/qnYriF9KiU47sRF0rTvfQmJo4JEmFMhCk2SJIsUj+hGnQaxkwaKfyvK9KenX20JNTQmVfJOz7VWe0cSntw=="
@@ -952,13 +964,18 @@
   "resolved" "https://registry.npmjs.org/joycon/-/joycon-3.0.1.tgz"
   "version" "3.0.1"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  "integrity" "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+  "resolved" "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
+  "version" "4.0.0"
+
 "kleur@^4.1.4":
   "integrity" "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
   "resolved" "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz"
   "version" "4.1.4"
 
 "level-blobs@^0.1.7":
-  "integrity" "sha1-mrm5e7mfHtv594o0M+Ie1WOGva8="
+  "integrity" "sha1-mrm5e7mfHtv594o0M+Ie1WOGva8= sha512-n0iYYCGozLd36m/Pzm206+brIgXP8mxPZazZ6ZvgKr+8YwOZ8/PPpYC5zMUu2qFygRN8RO6WC/HH3XWMW7RMVg=="
   "resolved" "https://registry.npmjs.org/level-blobs/-/level-blobs-0.1.7.tgz"
   "version" "0.1.7"
   dependencies:
@@ -967,7 +984,7 @@
     "readable-stream" "^1.0.26-4"
 
 "level-filesystem@^1.0.1":
-  "integrity" "sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M="
+  "integrity" "sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M= sha512-PhXDuCNYpngpxp3jwMT9AYBMgOvB6zxj3DeuIywNKmZqFj2djj9XfT2XDVslfqmo0Ip79cAd3SBy3FsfOZPJ1g=="
   "resolved" "https://registry.npmjs.org/level-filesystem/-/level-filesystem-1.2.0.tgz"
   "version" "1.2.0"
   dependencies:
@@ -982,26 +999,26 @@
     "xtend" "^2.2.0"
 
 "level-fix-range@~1.0.2":
-  "integrity" "sha1-vxW5Fa422EcMgh6IPd95zRZCCCg="
+  "integrity" "sha1-vxW5Fa422EcMgh6IPd95zRZCCCg= sha512-9llaVn6uqBiSlBP+wKiIEoBa01FwEISFgHSZiyec2S0KpyLUkGR4afW/FCZ/X8y+QJvzS0u4PGOlZDdh1/1avQ=="
   "resolved" "https://registry.npmjs.org/level-fix-range/-/level-fix-range-1.0.2.tgz"
   "version" "1.0.2"
 
 "level-fix-range@2.0":
-  "integrity" "sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug="
+  "integrity" "sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug= sha512-WrLfGWgwWbYPrHsYzJau+5+te89dUbENBg3/lsxOs4p2tYOhCHjbgXxBAj4DFqp3k/XBwitcRXoCh8RoCogASA=="
   "resolved" "https://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz"
   "version" "2.0.0"
   dependencies:
     "clone" "~0.1.9"
 
 "level-hooks@>=4.4.0 <5":
-  "integrity" "sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM="
+  "integrity" "sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM= sha512-fxLNny/vL/G4PnkLhWsbHnEaRi+A/k8r5EH/M77npZwYL62RHi2fV0S824z3QdpAk6VTgisJwIRywzBHLK4ZVA=="
   "resolved" "https://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz"
   "version" "4.5.0"
   dependencies:
     "string-range" "~1.2"
 
 "level-js@^2.1.3":
-  "integrity" "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc="
+  "integrity" "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc= sha512-lZtjt4ZwHE00UMC1vAb271p9qzg8vKlnDeXfIesH3zL0KxhHRDjClQLGLWhyR0nK4XARnd4wc/9eD1ffd4PshQ=="
   "resolved" "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz"
   "version" "2.2.4"
   dependencies:
@@ -1013,14 +1030,14 @@
     "xtend" "~2.1.2"
 
 "level-peek@^1.0.6", "level-peek@1.0.6":
-  "integrity" "sha1-vsUccqgu5GTTNkNMfIdsP8vM538="
+  "integrity" "sha1-vsUccqgu5GTTNkNMfIdsP8vM538= sha512-TKEzH5TxROTjQxWMczt9sizVgnmJ4F3hotBI48xCTYvOKd/4gA/uY0XjKkhJFo6BMic8Tqjf6jFMLWeg3MAbqQ=="
   "resolved" "https://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz"
   "version" "1.0.6"
   dependencies:
     "level-fix-range" "~1.0.2"
 
 "level-sublevel@^5.2.0":
-  "integrity" "sha1-dEwSxy0ucr543eO5tc2E1iGRQTo="
+  "integrity" "sha1-dEwSxy0ucr543eO5tc2E1iGRQTo= sha512-tO8jrFp+QZYrxx/Gnmjawuh1UBiifpvKNAcm4KCogesWr1Nm2+ckARitf+Oo7xg4OHqMW76eAqQ204BoIlscjA=="
   "resolved" "https://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz"
   "version" "5.2.3"
   dependencies:
@@ -1030,7 +1047,7 @@
     "xtend" "~2.0.4"
 
 "levelup@^0.18.2":
-  "integrity" "sha1-5qAcsIlhbI7MApHCqb0/DETj5es="
+  "integrity" "sha1-5qAcsIlhbI7MApHCqb0/DETj5es= sha512-uB0auyRqIVXx+hrpIUtol4VAPhLRcnxcOsd2i2m6rbFIDarO5dnrupLOStYYpEcu8ZT087Z9HEuYw1wjr6RL6Q=="
   "resolved" "https://registry.npmjs.org/levelup/-/levelup-0.18.6.tgz"
   "version" "0.18.6"
   dependencies:
@@ -1048,7 +1065,7 @@
   "version" "2.0.3"
 
 "lines-and-columns@^1.1.6":
-  "integrity" "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+  "integrity" "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA= sha512-8ZmlJFVK9iCmtLz19HpSsR8HaAMWBT284VMNednLwlIMDP2hJDCIhUp0IZ2xUcZ+Ob6BM0VvCSJwzASDM45NLQ=="
   "resolved" "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz"
   "version" "1.1.6"
 
@@ -1062,8 +1079,15 @@
   "resolved" "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   "version" "4.17.21"
 
+"loose-envify@^1.1.0":
+  "integrity" "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="
+  "resolved" "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
+  "version" "1.4.0"
+  dependencies:
+    "js-tokens" "^3.0.0 || ^4.0.0"
+
 "ltgt@^2.1.2":
-  "integrity" "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+  "integrity" "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU= sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA=="
   "resolved" "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz"
   "version" "2.2.1"
 
@@ -1120,7 +1144,7 @@
   "version" "1.0.1"
 
 "minimalistic-crypto-utils@^1.0.1":
-  "integrity" "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+  "integrity" "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo= sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
   "resolved" "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   "version" "1.0.1"
 
@@ -1181,7 +1205,7 @@
   "version" "4.4.0"
 
 "node-modules-regexp@^1.0.0":
-  "integrity" "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+  "integrity" "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA= sha512-JMaRS9L4wSRIR+6PTVEikTrq/lMGEZR43a48ETeilY0Q0iMwVnccMFrUM1k+tNzmYuIU0Vh710bCUqHX+/+ctQ=="
   "resolved" "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz"
   "version" "1.0.0"
 
@@ -1198,12 +1222,12 @@
     "path-key" "^3.0.0"
 
 "object-assign@^4.0.1":
-  "integrity" "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+  "integrity" "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM= sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
   "resolved" "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   "version" "4.1.1"
 
 "object-keys@~0.2.0":
-  "integrity" "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc="
+  "integrity" "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc= sha512-XODjdR2pBh/1qrjPcbSeSgEtKbYo7LqYNq64/TPuCf7j9SfDD3i21yatKoIy39yIWNvVM59iutfQQpCv1RfFzA=="
   "resolved" "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz"
   "version" "0.2.0"
   dependencies:
@@ -1212,17 +1236,17 @@
     "is" "~0.2.6"
 
 "object-keys@~0.4.0":
-  "integrity" "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+  "integrity" "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY= sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw=="
   "resolved" "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
   "version" "0.4.0"
 
 "octal@^1.0.0":
-  "integrity" "sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws="
+  "integrity" "sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws= sha512-nnda7W8d+A3vEIY+UrDQzzboPf1vhs4JYVhff5CDkq9QNoZY7Xrxeo/htox37j9dZf7yNHevZzqtejWgy1vCqQ=="
   "resolved" "https://registry.npmjs.org/octal/-/octal-1.0.0.tgz"
   "version" "1.0.0"
 
 "once@^1.3.0":
-  "integrity" "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+  "integrity" "sha1-WDsap3WWHUsROsF9nFC6753Xa9E= sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="
   "resolved" "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   "version" "1.4.0"
   dependencies:
@@ -1247,7 +1271,7 @@
     "safe-buffer" "^5.1.1"
 
 "path-is-absolute@^1.0.0":
-  "integrity" "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+  "integrity" "sha1-F0uSaHNVNP+8es5r9TpanhtcX18= sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
   "resolved" "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   "version" "1.0.1"
 
@@ -1267,7 +1291,7 @@
   "version" "4.0.0"
 
 "path@0.12.7":
-  "integrity" "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8="
+  "integrity" "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8= sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q=="
   "resolved" "https://registry.npmjs.org/path/-/path-0.12.7.tgz"
   "version" "0.12.7"
   dependencies:
@@ -1316,7 +1340,7 @@
     "source-map-js" "^0.6.2"
 
 "process-es6@^0.11.2":
-  "integrity" "sha1-xrs4n5qVH4K9TrFpYAEFvS/5x3g="
+  "integrity" "sha1-xrs4n5qVH4K9TrFpYAEFvS/5x3g= sha512-GYBRQtL4v3wgigq10Pv58jmTbFXlIiTbSfgnNqZLY0ldUPqy1rRxDI5fCjoCpnM6TqmHQI8ydzTBXW86OYc0gA=="
   "resolved" "https://registry.npmjs.org/process-es6/-/process-es6-0.11.6.tgz"
   "version" "0.11.6"
 
@@ -1326,7 +1350,7 @@
   "version" "2.0.1"
 
 "process@^0.11.1":
-  "integrity" "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+  "integrity" "sha1-czIwDoQBYb2j5podHZGn1LwW8YI= sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
   "resolved" "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
   "version" "0.11.10"
 
@@ -1336,12 +1360,12 @@
   "version" "2.0.4"
 
 "prr@~0.0.0":
-  "integrity" "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+  "integrity" "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo= sha512-LmUECmrW7RVj6mDWKjTXfKug7TFGdiz9P18HMcO4RHL+RW7MCOGNvpj5j47Rnp6ne6r4fZ2VzyUWEpKbg+tsjQ=="
   "resolved" "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
   "version" "0.0.0"
 
 "prr@~1.0.1":
-  "integrity" "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+  "integrity" "sha1-0/wRS6BplaRexok/SEzrHXj19HY= sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw=="
   "resolved" "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz"
   "version" "1.0.1"
 
@@ -1382,8 +1406,15 @@
     "randombytes" "^2.0.5"
     "safe-buffer" "^5.1.0"
 
+"react@18.2.0":
+  "integrity" "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="
+  "resolved" "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
+  "version" "18.2.0"
+  dependencies:
+    "loose-envify" "^1.1.0"
+
 "readable-stream@^1.0.26-4":
-  "integrity" "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+  "integrity" "sha1-fPTFTvZI44EwhMY23SB54WbAgdk= sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ=="
   "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
   "version" "1.1.14"
   dependencies:
@@ -1414,8 +1445,18 @@
     "string_decoder" "^1.1.1"
     "util-deprecate" "^1.0.1"
 
-"readable-stream@~1.0.26", "readable-stream@~1.0.26-4":
-  "integrity" "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+"readable-stream@~1.0.26-4":
+  "integrity" "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw= sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg=="
+  "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+  "version" "1.0.34"
+  dependencies:
+    "core-util-is" "~1.0.0"
+    "inherits" "~2.0.1"
+    "isarray" "0.0.1"
+    "string_decoder" "~0.10.x"
+
+"readable-stream@~1.0.26":
+  "integrity" "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw= sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg=="
   "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
   "version" "1.0.34"
   dependencies:
@@ -1450,7 +1491,7 @@
     "autolinker" "^3.11.0"
 
 "require-relative@^0.8.7":
-  "integrity" "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4="
+  "integrity" "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4= sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg=="
   "resolved" "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz"
   "version" "0.8.7"
 
@@ -1481,7 +1522,7 @@
     "inherits" "^2.0.1"
 
 "rollup-plugin-node-builtins@2.1.2":
-  "integrity" "sha1-JKH+1KQyV7a2Q3HYq8bOGrFFl+k="
+  "integrity" "sha1-JKH+1KQyV7a2Q3HYq8bOGrFFl+k= sha512-bxdnJw8jIivr2yEyt8IZSGqZkygIJOGAWypXvHXnwKAbUcN4Q/dGTx7K0oAJryC/m6aq6tKutltSeXtuogU6sw=="
   "resolved" "https://registry.npmjs.org/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.1.2.tgz"
   "version" "2.1.2"
   dependencies:
@@ -1534,7 +1575,7 @@
   "version" "2.1.2"
 
 "semver@~2.3.1":
-  "integrity" "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI="
+  "integrity" "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI= sha512-abLdIKCosKfpnmhS52NCTjO4RiLspDfsn37prjzGrp9im5DPJOgh82Os92vtwGh6XdQryKI/7SREZnV+aqiXrA=="
   "resolved" "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
   "version" "2.3.2"
 
@@ -1579,7 +1620,7 @@
   "version" "1.4.8"
 
 "sprintf-js@~1.0.2":
-  "integrity" "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+  "integrity" "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw= sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
   "resolved" "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   "version" "1.0.3"
 
@@ -1591,7 +1632,7 @@
     "safe-buffer" "~5.2.0"
 
 "string_decoder@~0.10.x":
-  "integrity" "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+  "integrity" "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ= sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
   "resolved" "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
   "version" "0.10.31"
 
@@ -1603,7 +1644,7 @@
     "safe-buffer" "~5.1.0"
 
 "string-range@~1.2", "string-range@~1.2.1":
-  "integrity" "sha1-qJPtNH5yKZvIO++78qaSqNI51d0="
+  "integrity" "sha1-qJPtNH5yKZvIO++78qaSqNI51d0= sha512-tYft6IFi8SjplJpxCUxyqisD3b+R2CSkomrtJYCkvuf1KuCAWgz7YXt4O0jip7efpfCemwHEzTEAO8EuOYgh3w=="
   "resolved" "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz"
   "version" "1.2.2"
 
@@ -1649,7 +1690,7 @@
   "version" "3.43.1"
 
 "thenify-all@^1.0.0":
-  "integrity" "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY="
+  "integrity" "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY= sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="
   "resolved" "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
   "version" "1.6.0"
   dependencies:
@@ -1670,7 +1711,7 @@
     "is-number" "^7.0.0"
 
 "toposort@^2.0.2":
-  "integrity" "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
+  "integrity" "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA= sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
   "resolved" "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz"
   "version" "2.0.2"
 
@@ -1689,7 +1730,7 @@
   "resolved" "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   "version" "1.14.1"
 
-"tslib@^2.1.0":
+"tslib@^2.1.0", "tslib@^2.4.0":
   "integrity" "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
   "resolved" "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz"
   "version" "2.4.0"
@@ -1738,12 +1779,12 @@
     "is-typedarray" "^1.0.0"
 
 "typedarray-to-buffer@~1.0.0":
-  "integrity" "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
+  "integrity" "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw= sha512-vjMKrfSoUDN8/Vnqitw2FmstOfuJ73G6CrSEKnf11A6RmasVxHqfeBcnTb6RsL4pTMuV5Zsv9IiHRphMZyckUw=="
   "resolved" "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz"
   "version" "1.0.4"
 
 "typedarray@^0.0.6":
-  "integrity" "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+  "integrity" "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c= sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
   "resolved" "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   "version" "0.0.6"
 
@@ -1755,7 +1796,7 @@
     "node-gyp-build" "^4.3.0"
 
 "util-deprecate@^1.0.1", "util-deprecate@~1.0.1":
-  "integrity" "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+  "integrity" "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8= sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
   "resolved" "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   "version" "1.0.2"
 
@@ -1826,7 +1867,7 @@
   "version" "4.0.15"
 
 "wrappy@1":
-  "integrity" "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+  "integrity" "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
   "resolved" "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   "version" "1.0.2"
 
@@ -1838,12 +1879,12 @@
     "async-limiter" "~1.0.0"
 
 "xtend@^2.2.0":
-  "integrity" "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
+  "integrity" "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak= sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw=="
   "resolved" "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz"
   "version" "2.2.0"
 
 "xtend@~2.0.4":
-  "integrity" "sha1-XqZXptukRwacLlnFihE4ywxebO4="
+  "integrity" "sha1-XqZXptukRwacLlnFihE4ywxebO4= sha512-fOZg4ECOlrMl+A6Msr7EIFcON1L26mb4NY5rurSkOex/TWhazOrg6eXD/B0XkuiYcYhQDWLXzQxLMVJ7LXwokg=="
   "resolved" "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz"
   "version" "2.0.6"
   dependencies:
@@ -1851,14 +1892,14 @@
     "object-keys" "~0.2.0"
 
 "xtend@~2.1.2":
-  "integrity" "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
+  "integrity" "sha1-bv7MKk2tjmlixJAbM3znuoe10os= sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ=="
   "resolved" "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
   "version" "2.1.2"
   dependencies:
     "object-keys" "~0.4.0"
 
 "xtend@~3.0.0":
-  "integrity" "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+  "integrity" "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo= sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg=="
   "resolved" "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
   "version" "3.0.0"
 

--- a/modd.conf
+++ b/modd.conf
@@ -15,7 +15,7 @@ internal/templates/sources/**/* {
   prep: go generate ./internal/templates/...
 }
 
-go.mod go.sum **/*.go !**/*_test.go !internal/graph/generated.go !internal/graph/models_gen.go internal/graph/*.resolvers.go  {
+go.mod go.sum **/*.go !**/*_test.go ../tajriba/**/*.go !../tajriba/**/*_test.go !internal/graph/generated.go !internal/graph/models_gen.go internal/graph/*.resolvers.go  {
   # prep: go install -race ./cmds/empirica
   prep: go install -ldflags "-X 'github.com/empiricaly/empirica/internal/build.DevBuild=true' -X 'github.com/empiricaly/empirica/internal/build.SHA=abcd123' -X 'github.com/empiricaly/empirica/internal/build.Tag=v1.2.3' -X 'github.com/empiricaly/empirica/internal/build.Branch=thisbranch' -X 'github.com/empiricaly/empirica/internal/build.BuildNum=42' -X 'github.com/empiricaly/empirica/internal/build.Time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')'" ./cmds/empirica
   


### PR DESCRIPTION
Stage ordering has been relying on absolute ordering of stage indexes within a game. Also stage indexes were applied on callback finalizers in a loop where multiple stages on a round could acquire their stage index out of order.

Stages are now ordered within a round. This is done so that stages can be added to rounds out of order (add stage 1 to round 1, stage 1 to round 2 and stage 2 to round 1 ; this scenario would have made the stages go out of order). Also, rounds are now ordereds. Finally, all stages added at the same time as a round (within the same callback) should not be ordered.