### PR TITLE
feat(e2e): Implement e2e for lobby timeouts

### DIFF
--- a/e2e-tests/page-objects/admin/BatchesAdminPage.ts
+++ b/e2e-tests/page-objects/admin/BatchesAdminPage.ts
@@ -16,6 +16,8 @@ export enum GamesStatus {
 
 export enum BatchStatus {
   "Created" = "Created",
+  "Running" = "Running",
+  "Ended" = "Ended",
   "Terminated" = "Terminated",
 }
 
@@ -45,11 +47,15 @@ export default class BatchesAdminPage extends BasePage {
   }
 
   private getBatchStatusElement(batchNumber: number, status: BatchStatus) {
-    return this.page.locator('[data-test="batchLine"]').getByText(status);
+    return this.page.locator('[data-test="batchLine"] span').getByText(status);
   }
 
   private getGamesList(batchNumber: number) {
     return this.getGameBatchLine(batchNumber).locator("ul");
+  }
+
+  private getLobbyConfigrationList() {
+    return this.page.locator('[data-test="lobbySelect"]');
   }
 
   private getStartGameButton() {
@@ -84,6 +90,14 @@ export default class BatchesAdminPage extends BasePage {
     await gamesCountInput.fill(`${count}`);
   }
 
+  private async selectLobbyConfiguration(name: string) {
+    const configrationsList = await this.getLobbyConfigrationList();
+
+    expect(configrationsList).toBeVisible();
+
+    await configrationsList.selectOption({ label: name });
+  }
+
   public async open() {
     await this.initContext();
 
@@ -101,21 +115,23 @@ export default class BatchesAdminPage extends BasePage {
   public async createBatch({
     mode,
     gamesCount,
+    lobbyConfigrationName,
   }: {
     mode: GamesTypeTreatment;
     gamesCount: number;
+    lobbyConfigrationName?: string;
   }) {
-    const newBatchButton = await this.getNewBatchButton();
-
-    await newBatchButton.click();
+    await this.getNewBatchButton().click();
 
     await this.selectTreatmeant(mode);
 
     await this.selectGamesCount(gamesCount);
 
-    const createBatchButton = await this.getCreateBatchButton();
+    if (lobbyConfigrationName) {
+      await this.selectLobbyConfiguration(lobbyConfigrationName);
+    }
 
-    await createBatchButton.click();
+    await this.getCreateBatchButton().click();
   }
 
   public async checkGameStatus(
@@ -132,6 +148,8 @@ export default class BatchesAdminPage extends BasePage {
 
     const statusElement = await gameItem.getByText(status);
 
+    // TODO: this should be awaited! fix this issue:
+    // await expect(statusElement).toBeVisible();
     expect(statusElement).toBeVisible();
   }
 

--- a/e2e-tests/page-objects/admin/LobbiesAdminPage.ts
+++ b/e2e-tests/page-objects/admin/LobbiesAdminPage.ts
@@ -1,0 +1,141 @@
+import { expect } from "@playwright/test";
+import BasePage from "../BasePage";
+
+export enum LobbyTimeoutKind {
+  "Shared" = "Shared",
+  "Individual" = "Individual",
+}
+
+export enum LobbyTimeoutStrategy {
+  "Fail" = "Fail",
+  "Ignore" = "Ignore",
+}
+
+type NewLobbyTimeoutParams = {
+  name: string;
+  description?: string;
+  kind: LobbyTimeoutKind;
+  duration: string;
+  strategy?: LobbyTimeoutStrategy;
+};
+
+export default class LobbiesAdminPage extends BasePage {
+  private getLobbiesLinkInSidebar() {
+    return this.page.locator('[data-test="lobbiesSidebarButton"]');
+  }
+
+  private getNewConfigurationButton() {
+    return this.page.locator('[data-test="newLobbyButton"]');
+  }
+
+  private getNameInput() {
+    return this.page.locator('input[id="name"]');
+  }
+
+  private getDescriptionField() {
+    return this.page.locator('textarea[id="description"]');
+  }
+
+  private getSharedKindButton() {
+    return this.page.locator('[data-test="sharedKindButton"]');
+  }
+
+  private getIndividualKindButton() {
+    return this.page.locator('[data-test="individualKindButton"]');
+  }
+
+  private getDurationInout() {
+    return this.page.locator('[data-test="durationInput"]');
+  }
+
+  private getFailStrategyButton() {
+    return this.page.locator('[data-test="failStrategyButton"]');
+  }
+
+  private getIgnoreStrategyButton() {
+    return this.page.locator('[data-test="ignoreStrategyButton"]');
+  }
+
+  private getSaveConfigrationButton() {
+    return this.page.locator('button[type="submit"]');
+  }
+
+  public async open() {
+    await this.initContext();
+
+    await this.page.goto(`${this.baseUrl}/admin`);
+
+    const batchesSidebarButton = await this.getLobbiesLinkInSidebar();
+
+    await batchesSidebarButton.click();
+
+    const newBatchButton = await this.getNewConfigurationButton();
+
+    await expect(newBatchButton).toBeVisible();
+  }
+
+  public async selectKind(kind: LobbyTimeoutKind) {
+    if (kind === LobbyTimeoutKind.Shared) {
+      await this.getSharedKindButton().click();
+    }
+
+    if (kind === LobbyTimeoutKind.Individual) {
+      await this.getIndividualKindButton().click();
+    }
+  }
+
+  public async selectStrategy(strategy: LobbyTimeoutStrategy) {
+    if (strategy === LobbyTimeoutStrategy.Fail) {
+      await this.getFailStrategyButton().click();
+    }
+
+    if (strategy === LobbyTimeoutStrategy.Ignore) {
+      await this.getIgnoreStrategyButton().click();
+    }
+  }
+
+  public static getLobbyName(config: NewLobbyTimeoutParams) {
+    const strategyName =
+      config.kind === LobbyTimeoutKind.Shared
+        ? config?.strategy?.toLowerCase()
+        : "0";
+
+    return `${config.name} - ${config.kind} / ${config.duration} / ${strategyName}`;
+  }
+
+  public async createNewLobbyConfiguration({
+    name,
+    description,
+    kind,
+    duration,
+    strategy,
+  }: NewLobbyTimeoutParams) {
+    await this.getNewConfigurationButton().click();
+
+    const nameInput = await this.getNameInput();
+
+    await expect(nameInput).toBeVisible();
+
+    nameInput.fill(name);
+
+    if (description) {
+      const descriptionField = await this.getDescriptionField();
+
+      await expect(descriptionField).toBeVisible();
+
+      await descriptionField.fill(description);
+    }
+
+    await this.getDurationInout().fill(duration);
+
+    await this.selectKind(kind);
+
+    if (kind === LobbyTimeoutKind.Shared && strategy) {
+      await this.selectStrategy(strategy);
+    }
+
+    await this.getSaveConfigrationButton().click();
+  }
+
+  // public async checkLobbyConfigurationVisible() {}
+}

--- a/e2e-tests/page-objects/admin/PlayersPage.ts
+++ b/e2e-tests/page-objects/admin/PlayersPage.ts
@@ -7,8 +7,12 @@ export default class PlayersPage extends BasePage {
 
     await this.page.goto(`${this.baseUrl}/admin`);
 
-    const leftPanel = await this.page.locator('[aria-label="Sidebar"]');
+    const batchesSidebarButton = await this.getLobbiesLinkInSidebar();
 
-    await expect(leftPanel).toBeVisible();
+    await batchesSidebarButton.click();
+
+    const newBatchButton = await this.getNewConfigurationButton();
+
+    await expect(newBatchButton).toBeVisible();
   }
 }

--- a/e2e-tests/page-objects/main/ExperimentPage.ts
+++ b/e2e-tests/page-objects/main/ExperimentPage.ts
@@ -8,6 +8,7 @@ import ExitSurveyElement from "./elements/ExitSurveyElement";
 import ConsentElement from "./elements/ConsentElement";
 import MinesweeperGameElement from "./elements/MinesweeperGameElement";
 import TimerElement from "./elements/TimerElement";
+import WaitingOtherPlayersElement from "./elements/WaitingOtherPlayersElement";
 
 export default class ExperimentPage extends BasePage {
   private noExperimentsElement: NoExperimentsElement;
@@ -22,6 +23,8 @@ export default class ExperimentPage extends BasePage {
 
   private minesweeperGameElement: MinesweeperGameElement;
 
+  private waitingOtherPlayersElement: WaitingOtherPlayersElement;
+
   private consentElement: ConsentElement;
 
   private finishedElement: FinishedElement;
@@ -35,6 +38,7 @@ export default class ExperimentPage extends BasePage {
 
     this.loginElement = new LoginElement({ page });
     this.noExperimentsElement = new NoExperimentsElement({ page });
+    this.waitingOtherPlayersElement = new WaitingOtherPlayersElement({ page });
     this.consentElement = new ConsentElement({ page });
     this.instructionsElement = new InstructionsElement({ page });
     this.exitSurveyElement = new ExitSurveyElement({ page });
@@ -72,6 +76,10 @@ export default class ExperimentPage extends BasePage {
 
   public async checkIfJellyBeansVisible() {
     await this.jellyBeansGame.checkIfVisible();
+  }
+
+  public async checkIfLobbyVisible() {
+    await this.waitingOtherPlayersElement.checkIfVisible();
   }
 
   public async selectJellyBeansCount({ count }: { count: number }) {

--- a/e2e-tests/tests/lobby-timeouts-individual.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-individual.spec.ts
@@ -1,0 +1,95 @@
+import { test } from "@playwright/test";
+import ExperimentPage from "../page-objects/main/ExperimentPage";
+import BatchesAdminPage, {
+  BatchStatus,
+  GamesTypeTreatment,
+} from "../page-objects/admin/BatchesAdminPage";
+import EmpiricaTestFactory from "../setup/EmpiricaTestFactory";
+import { createPlayer } from "../utils/playerUtils";
+
+import { baseUrl } from "../setup/setupConstants";
+import LobbiesAdminPage, {
+  LobbyTimeoutKind,
+  LobbyTimeoutStrategy,
+} from "../page-objects/admin/LobbiesAdminPage";
+
+const testFactory = new EmpiricaTestFactory();
+
+test.beforeAll(async () => {
+  await testFactory.init();
+});
+
+test.afterAll(async () => {
+  await testFactory.teardown();
+});
+
+test.describe("Lobby timeouts in Empirica", () => {
+  test("create configuration with a individual lobby timeout", async ({
+    browser,
+  }) => {
+    const batchesPage = new BatchesAdminPage({
+      browser,
+      baseUrl,
+    });
+    const lobbiesPage = new LobbiesAdminPage({
+      browser,
+      baseUrl,
+    });
+
+    const player1 = createPlayer();
+    const gamesCount = 1;
+    const gameMode = GamesTypeTreatment.TwoPlayers;
+    const lobbyConfigration = {
+      name: "test",
+      description: "Testing individual lobby timeout",
+      duration: "5s",
+      kind: LobbyTimeoutKind.Individual,
+    };
+
+    await lobbiesPage.open();
+
+    await lobbiesPage.createNewLobbyConfiguration(lobbyConfigration);
+
+    await batchesPage.open();
+
+    await batchesPage.createBatch({
+      mode: gameMode,
+      gamesCount,
+      lobbyConfigrationName: LobbiesAdminPage.getLobbyName(lobbyConfigration),
+    });
+
+    await batchesPage.checkBatchStatus({
+      batchNumber: 0,
+      status: BatchStatus.Created,
+    });
+
+    await batchesPage.startGame();
+
+    const player1Page = new ExperimentPage({
+      browser,
+      baseUrl,
+    });
+
+    await player1Page.open();
+
+    await player1Page.acceptConsent();
+
+    await player1Page.login({ playerId: player1.id });
+
+    await player1Page.passInstructions();
+
+    // Here we'd wait for 5 seconds until the player gets kicked out
+
+    await player1Page.fillExitSurvey({
+      age: player1.age,
+      gender: player1.gender,
+    });
+
+    await batchesPage.checkBatchStatus({
+      batchNumber: 0,
+      status: BatchStatus.Created,
+    });
+
+    await player1Page.checkIfFinished();
+  });
+});

--- a/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
@@ -1,0 +1,105 @@
+import { test } from "@playwright/test";
+import ExperimentPage from "../page-objects/main/ExperimentPage";
+import BatchesAdminPage, {
+  BatchStatus,
+  GamesTypeTreatment,
+} from "../page-objects/admin/BatchesAdminPage";
+import EmpiricaTestFactory from "../setup/EmpiricaTestFactory";
+import { createPlayer } from "../utils/playerUtils";
+
+import { baseUrl } from "../setup/setupConstants";
+import LobbiesAdminPage, {
+  LobbyTimeoutKind,
+  LobbyTimeoutStrategy,
+} from "../page-objects/admin/LobbiesAdminPage";
+
+const testFactory = new EmpiricaTestFactory();
+
+test.beforeAll(async () => {
+  await testFactory.init();
+});
+
+test.afterAll(async () => {
+  await testFactory.teardown();
+});
+
+test.describe("Lobby timeouts in Empirica", () => {
+  test("create configuration with a shared lobby timeout, fail strategy", async ({
+    browser,
+  }) => {
+    const batchesPage = new BatchesAdminPage({
+      browser,
+      baseUrl,
+    });
+    const lobbiesPage = new LobbiesAdminPage({
+      browser,
+      baseUrl,
+    });
+
+    const player1 = createPlayer();
+    const gamesCount = 1;
+    const gameMode = GamesTypeTreatment.TwoPlayers;
+    const lobbyConfigration = {
+      name: "test",
+      description: "Testing shared lobby timeout with a fail strategy",
+      duration: "5s",
+      kind: LobbyTimeoutKind.Shared,
+      strategy: LobbyTimeoutStrategy.Fail,
+    };
+
+    await lobbiesPage.open();
+
+    await lobbiesPage.createNewLobbyConfiguration(lobbyConfigration);
+
+    await batchesPage.open();
+
+    await batchesPage.createBatch({
+      mode: gameMode,
+      gamesCount,
+      lobbyConfigrationName: LobbiesAdminPage.getLobbyName(lobbyConfigration),
+    });
+
+    await batchesPage.checkBatchStatus({
+      batchNumber: 0,
+      status: BatchStatus.Created,
+    });
+
+    await batchesPage.startGame();
+
+    const player1Page = new ExperimentPage({
+      browser,
+      baseUrl,
+    });
+
+    const player2Page = new ExperimentPage({
+      browser,
+      baseUrl,
+    });
+
+    await player1Page.open();
+    await player2Page.open();
+
+    // Only player 1 logs in, player 2 stays in the instructions
+    await player1Page.acceptConsent();
+
+    await player1Page.login({ playerId: player1.id });
+
+    await player1Page.passInstructions();
+
+    // Here we'd wait for 5 seconds until the player gets kicked out because player 2 hasn't joined
+
+    await player2Page.checkIfNoExperimentsVisible();
+
+    await player1Page.fillExitSurvey({
+      age: player1.age,
+      gender: player1.gender,
+    });
+
+    await batchesPage.checkBatchStatus({
+      batchNumber: 0,
+      status: BatchStatus.Ended,
+    });
+
+    await player1Page.checkIfFinished();
+  });
+});

--- a/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
@@ -1,0 +1,109 @@
+import { test } from "@playwright/test";
+import ExperimentPage from "../page-objects/main/ExperimentPage";
+import BatchesAdminPage, {
+  BatchStatus,
+  GamesTypeTreatment,
+} from "../page-objects/admin/BatchesAdminPage";
+import EmpiricaTestFactory from "../setup/EmpiricaTestFactory";
+import { createPlayer } from "../utils/playerUtils";
+
+import { baseUrl } from "../setup/setupConstants";
+import LobbiesAdminPage, {
+  LobbyTimeoutKind,
+  LobbyTimeoutStrategy,
+} from "../page-objects/admin/LobbiesAdminPage";
+
+const testFactory = new EmpiricaTestFactory();
+
+test.beforeAll(async () => {
+  await testFactory.init();
+});
+
+test.afterAll(async () => {
+  await testFactory.teardown();
+});
+
+test.describe("Lobby timeouts in Empirica", () => {
+  test("create configuration with a shared lobby timeout, ignore strategy", async ({
+    browser,
+  }) => {
+    const batchesPage = new BatchesAdminPage({
+      browser,
+      baseUrl,
+    });
+    const lobbiesPage = new LobbiesAdminPage({
+      browser,
+      baseUrl,
+    });
+
+    const player1 = createPlayer();
+    const gamesCount = 1;
+    const gameMode = GamesTypeTreatment.TwoPlayers;
+    const lobbyConfigration = {
+      name: "test",
+      description: "Testing shared lobby timeout with an ignore strategy",
+      duration: "5s",
+      kind: LobbyTimeoutKind.Shared,
+      strategy: LobbyTimeoutStrategy.Ignore,
+    };
+
+    await lobbiesPage.open();
+
+    await lobbiesPage.createNewLobbyConfiguration(lobbyConfigration);
+
+    await batchesPage.open();
+
+    await batchesPage.createBatch({
+      mode: gameMode,
+      gamesCount,
+      lobbyConfigrationName: LobbiesAdminPage.getLobbyName(lobbyConfigration),
+    });
+
+    await batchesPage.checkBatchStatus({
+      batchNumber: 0,
+      status: BatchStatus.Created,
+    });
+
+    await batchesPage.startGame();
+
+    const player1Page = new ExperimentPage({
+      browser,
+      baseUrl,
+    });
+
+    const player2Page = new ExperimentPage({
+      browser,
+      baseUrl,
+    });
+
+    await player1Page.open();
+    await player2Page.open();
+
+    // Only player 1 logs in, player 2 stays in the instructions
+    await player1Page.acceptConsent();
+
+    await player1Page.login({ playerId: player1.id });
+
+    await player1Page.passInstructions();
+
+    // Here we'd wait for 5 seconds until the player 1 joins as a single player because player 2 hasn't joined
+
+    await player2Page.checkIfNoExperimentsVisible();
+
+    await player1Page.playJellyBeanGame({ count: 125 });
+
+    await player1Page.passMineSweeper();
+
+    await player1Page.fillExitSurvey({
+      age: player1.age,
+      gender: player1.gender,
+    });
+
+    await batchesPage.checkBatchStatus({
+      batchNumber: 0,
+      status: BatchStatus.Ended,
+    });
+
+    await player1Page.checkIfFinished();
+  });
+});

--- a/e2e-tests/utils/versionUtils.ts
+++ b/e2e-tests/utils/versionUtils.ts
@@ -24,8 +24,6 @@ function parseValueFromString(string: string, regexp: RegExp) {
 
   const valueMatch = Array.isArray(parseResult) ? parseResult[1] : null;
 
-  console.log({ valueMatch });
-
   return valueMatch;
 }
 


### PR DESCRIPTION
Added e2e tests for:

1. Shared timeouts with "fail" strategy
2. Shared timeouts with "ignore" strategy
3. Individual timeout