### PR TITLE
Improve e2e tests performance

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -20,7 +20,7 @@ jobs:
       
       - name: Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")"
       - name: Cache playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
@@ -34,7 +34,6 @@ jobs:
       - name: test:e2e
         run: npm run test:e2e -w ./e2e-tests
       - uses: actions/upload-artifact@v2
-
         if: always()
         with:
           name: playwright-test-results

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -20,7 +20,7 @@ jobs:
       
       - name: Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")"
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
       - name: Cache playwright binaries
         uses: actions/cache@v3
         id: playwright-cache

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -4,6 +4,7 @@ jobs:
   tests_e2e:
     name: Run end-to-end tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -16,7 +17,25 @@ jobs:
       - name: install @empirica core dependencies
         working-directory: ./lib/@empirica/core
         run: npm ci
+      
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
       - name: install playwright browsers
         run: npm run install_browsers -w ./e2e-tests
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: test:e2e
         run: npm run test:e2e -w ./e2e-tests
+      - uses: actions/upload-artifact@v2
+
+        if: always()
+        with:
+          name: playwright-test-results
+          path: ./e2e-tests/test-results/

--- a/e2e-tests/.eslintrc.js
+++ b/e2e-tests/.eslintrc.js
@@ -3,5 +3,7 @@ module.exports = {
   rules: {
     "class-methods-use-this": 0,
     "no-console": 0,
+    "no-restricted-syntax": 0,
+    "no-await-in-loop": 0,
   },
 };

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@playwright/test": "^1.29.2",
+    "@playwright/test": "^1.28.0",
     "@types/tar": "^6.1.3",
     "tar": "^6.1.13",
     "uuid": "^9.0.0"

--- a/e2e-tests/page-objects/BasePage.ts
+++ b/e2e-tests/page-objects/BasePage.ts
@@ -5,9 +5,14 @@ export type BasePageConstructor = {
   baseUrl?: string;
 };
 
+export interface BasePageConstructorInterface {
+  new (options: BasePageConstructor): BasePage;
+}
+
 export interface BasePageInterface {
   open: () => Promise<void>;
   init: () => Promise<void>;
+  close: () => Promise<void>;
 }
 
 export default class BasePage implements BasePageInterface {

--- a/e2e-tests/page-objects/BasePage.ts
+++ b/e2e-tests/page-objects/BasePage.ts
@@ -50,4 +50,8 @@ export default class BasePage implements BasePageInterface {
       await this.page.goto(this.baseUrl);
     }
   }
+
+  public async close() {
+    await this.context.close();
+  }
 }

--- a/e2e-tests/page-objects/admin/BatchesAdminPage.ts
+++ b/e2e-tests/page-objects/admin/BatchesAdminPage.ts
@@ -121,6 +121,8 @@ export default class BatchesAdminPage extends BasePage {
     gamesCount: number;
     lobbyConfigrationName?: string;
   }) {
+    await this.page.waitForTimeout(200);
+
     await this.getNewBatchButton().click();
 
     await this.selectTreatmeant(mode);

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -13,7 +13,7 @@ import { devices } from "@playwright/test";
 const config: PlaywrightTestConfig = {
   testDir: "./tests",
   /* Maximum time one test can run for. */
-  timeout: 240 * 1000,
+  timeout: 120 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
@@ -41,6 +41,8 @@ const config: PlaywrightTestConfig = {
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
+    /* Turn headless to false in order to see the browser windows */
+    headless: true,
   },
 
   /* Configure projects for major browsers */

--- a/e2e-tests/setup/EmpiricaTestFactory.ts
+++ b/e2e-tests/setup/EmpiricaTestFactory.ts
@@ -90,8 +90,12 @@ export default class EmpiricaTestFactory {
   }
 
   async teardown() {
+    console.log(`Teardown, project id: ${this.getProjectId()}`);
+
     await this.stopEmpiricaProject();
     await this.fullCleanup();
+
+    console.log("Cleanup finished");
   }
 
   async fullCleanup() {
@@ -260,12 +264,16 @@ export default class EmpiricaTestFactory {
   }
 
   private async stopEmpiricaProject() {
+    console.log("Trying to kill Empirica process");
+
     return new Promise((resolve) => {
       try {
         this.empiricaProcess.stdout.destroy();
         this.empiricaProcess.stderr.destroy();
 
         this.empiricaProcess.kill();
+
+        console.log("Killed Empirica process");
 
         resolve(true);
       } catch (e) {

--- a/e2e-tests/setup/EmpiricaTestFactory.ts
+++ b/e2e-tests/setup/EmpiricaTestFactory.ts
@@ -35,6 +35,7 @@ const CACHE_FOLDER = "cache";
 interface TestFactoryParams {
   shouldBuildCorePackage: boolean;
   shoudLinkCoreLib: boolean;
+  shouldUseCache: boolean;
 }
 
 export default class EmpiricaTestFactory {
@@ -292,7 +293,7 @@ export default class EmpiricaTestFactory {
         // this.empiricaProcess.kill();
         process.kill(this.empiricaProcess.pid, "SIGKILL");
 
-        // await killPortProcess(8844);
+        childProcess.exec("kill -9 $(lsof -t -i:8844)");
 
         console.log("Killed Empirica process");
 

--- a/e2e-tests/setup/EmpiricaTestFactory.ts
+++ b/e2e-tests/setup/EmpiricaTestFactory.ts
@@ -287,8 +287,14 @@ export default class EmpiricaTestFactory {
         this.empiricaProcess.stdout.destroy();
         this.empiricaProcess.stderr.destroy();
 
+        // This would send a kill signal to the child process
+        // but it doesn't verify that the process has been really killed
+        // see https://nodejs.org/api/child_process.html#subprocesskilled for details
+        // and also: https://github.com/nodejs/node/issues/27490
         process.kill(this.empiricaProcess.pid, "SIGKILL");
 
+        // Sometimes, the process is not killed by the command above
+        // so we might need to call the kill cmd in the system
         childProcess.exec("kill -9 $(lsof -t -i:8844)");
 
         console.log("Killed Empirica process");

--- a/e2e-tests/setup/EmpiricaTestFactory.ts
+++ b/e2e-tests/setup/EmpiricaTestFactory.ts
@@ -272,7 +272,11 @@ export default class EmpiricaTestFactory {
       });
 
       this.empiricaProcess?.on("close", (code) => {
-        console.log(`"${EMPIRICA_CMD}" process exited with code ${code}`);
+        console.log(`"${EMPIRICA_CMD}" process closed with code ${code}`);
+      });
+
+      this.empiricaProcess?.on("exit", (code, signal) => {
+        console.log(`"${EMPIRICA_CMD}" process exited with code ${code}, signal "${signal}"`);
       });
     });
   }
@@ -280,12 +284,15 @@ export default class EmpiricaTestFactory {
   private async stopEmpiricaProject() {
     console.log("Trying to kill Empirica process");
 
-    return new Promise((resolve) => {
+    return new Promise(async (resolve) => {
       try {
         this.empiricaProcess.stdout.destroy();
         this.empiricaProcess.stderr.destroy();
 
-        this.empiricaProcess.kill();
+        // this.empiricaProcess.kill();
+        process.kill(this.empiricaProcess.pid, "SIGKILL");
+
+        // await killPortProcess(8844);
 
         console.log("Killed Empirica process");
 
@@ -293,8 +300,7 @@ export default class EmpiricaTestFactory {
       } catch (e) {
         console.error("Failed to kill Empirica process", e);
 
-        process.kill(this.empiricaProcess.pid, "SIGKILL");
-
+        
         resolve(false);
       }
     });

--- a/e2e-tests/setup/EmpiricaTestFactory.ts
+++ b/e2e-tests/setup/EmpiricaTestFactory.ts
@@ -139,7 +139,8 @@ export default class EmpiricaTestFactory {
   }
 
   private async createRootDirectory() {
-    return fs.mkdtemp(path.join(os.tmpdir(), "empirica-test"));
+    // return fs.mkdtemp(path.join(os.tmpdir(), "empirica-test"));
+    return fs.mkdtemp(path.join(__dirname,"..", "..","..", "empirica-test-"));
   }
 
   private getRootDirectory() {

--- a/e2e-tests/setup/EmpiricaTestFactory.ts
+++ b/e2e-tests/setup/EmpiricaTestFactory.ts
@@ -1,5 +1,3 @@
-/* eslint-disable   */
-/* eslint-disable */
 import { promises as fs, constants } from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -35,7 +33,6 @@ const CACHE_FOLDER = "cache";
 interface TestFactoryParams {
   shouldBuildCorePackage: boolean;
   shoudLinkCoreLib: boolean;
-  shouldUseCache: boolean;
 }
 
 export default class EmpiricaTestFactory {
@@ -290,7 +287,6 @@ export default class EmpiricaTestFactory {
         this.empiricaProcess.stdout.destroy();
         this.empiricaProcess.stderr.destroy();
 
-        // this.empiricaProcess.kill();
         process.kill(this.empiricaProcess.pid, "SIGKILL");
 
         childProcess.exec("kill -9 $(lsof -t -i:8844)");
@@ -300,7 +296,6 @@ export default class EmpiricaTestFactory {
         resolve(true);
       } catch (e) {
         console.error("Failed to kill Empirica process", e);
-
         
         resolve(false);
       }

--- a/e2e-tests/setup/EmpiricaTestFactory.ts
+++ b/e2e-tests/setup/EmpiricaTestFactory.ts
@@ -261,9 +261,20 @@ export default class EmpiricaTestFactory {
 
   private async stopEmpiricaProject() {
     return new Promise((resolve) => {
-      this.empiricaProcess.kill();
+      try {
+        this.empiricaProcess.stdout.destroy();
+        this.empiricaProcess.stderr.destroy();
 
-      resolve(true);
+        this.empiricaProcess.kill();
+
+        resolve(true);
+      } catch (e) {
+        console.error("Failed to kill Empirica process", e);
+
+        process.kill(this.empiricaProcess.pid, "SIGKILL");
+
+        resolve(false);
+      }
     });
   }
 }

--- a/e2e-tests/setup/PageManager.ts
+++ b/e2e-tests/setup/PageManager.ts
@@ -1,0 +1,64 @@
+/* eslint-disable   */
+/* eslint-disable */
+import { promises as fs, constants } from "fs";
+import * as path from "path";
+import * as os from "os";
+import * as uuid from "uuid";
+import * as childProcess from "node:child_process";
+import { type Page, type Browser, type BrowserContext } from "@playwright/test";
+
+import * as tar from "tar";
+import executeCommand from "../utils/launchProcess";
+import {
+  EmpiricaVersion,
+  parseBranchName,
+  parseBuild,
+  parseVersion,
+} from "../utils/versionUtils";
+import BasePage, { BasePageConstructorInterface, BasePageInterface } from "../page-objects/BasePage";
+
+const EMPIRICA_CMD = "empirica";
+const EMPIRICA_CONFIG_RELATIVE_PATH = path.join(".empirica", "local");
+
+const EMPIRICA_CORE_PACKAGE_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "lib",
+  "@empirica",
+  "core"
+);
+
+const CACHE_FOLDER = "cache";
+
+interface TestFactoryParams {
+  shouldBuildCorePackage: boolean;
+  shoudLinkCoreLib: boolean;
+}
+
+
+export default class PageManager {
+  private pages: BasePage[];
+
+  constructor(params?: TestFactoryParams) {
+    this.pages = [];
+  }
+
+  public createPage<T extends BasePage>(pageClass: new (...a: any[]) => T, {browser, baseUrl}: { browser: Browser, baseUrl?: string}): T {
+    const page  = new pageClass({
+      browser,
+      baseUrl
+    })
+
+    this.pages.push(page);
+
+    return page;
+  }
+
+ 
+  public async cleanup() {
+    for (const page of this.pages) {
+      await page.close();
+    }
+  }
+}

--- a/e2e-tests/setup/PageManager.ts
+++ b/e2e-tests/setup/PageManager.ts
@@ -1,61 +1,30 @@
-/* eslint-disable   */
-/* eslint-disable */
-import { promises as fs, constants } from "fs";
-import * as path from "path";
-import * as os from "os";
-import * as uuid from "uuid";
-import * as childProcess from "node:child_process";
-import { type Page, type Browser, type BrowserContext } from "@playwright/test";
+import { type Browser } from "@playwright/test";
 
-import * as tar from "tar";
-import executeCommand from "../utils/launchProcess";
-import {
-  EmpiricaVersion,
-  parseBranchName,
-  parseBuild,
-  parseVersion,
-} from "../utils/versionUtils";
-import BasePage, { BasePageConstructorInterface, BasePageInterface } from "../page-objects/BasePage";
-
-const EMPIRICA_CMD = "empirica";
-const EMPIRICA_CONFIG_RELATIVE_PATH = path.join(".empirica", "local");
-
-const EMPIRICA_CORE_PACKAGE_PATH = path.join(
-  __dirname,
-  "..",
-  "..",
-  "lib",
-  "@empirica",
-  "core"
-);
-
-const CACHE_FOLDER = "cache";
-
-interface TestFactoryParams {
-  shouldBuildCorePackage: boolean;
-  shoudLinkCoreLib: boolean;
-}
-
+import BasePage from "../page-objects/BasePage";
 
 export default class PageManager {
   private pages: BasePage[];
 
-  constructor(params?: TestFactoryParams) {
+  constructor() {
     this.pages = [];
   }
 
-  public createPage<T extends BasePage>(pageClass: new (...a: any[]) => T, {browser, baseUrl}: { browser: Browser, baseUrl?: string}): T {
-    const page  = new pageClass({
+  // This method should accept a class that is inherited from the BasePage class and return the instance of it
+  public createPage<T extends BasePage>(
+    pageClass: new (...a: any[]) => T,
+    { browser, baseUrl }: { browser: Browser; baseUrl?: string }
+  ): T {
+    // eslint-disable-next-line new-cap
+    const page = new pageClass({
       browser,
-      baseUrl
-    })
+      baseUrl,
+    });
 
     this.pages.push(page);
 
     return page;
   }
 
- 
   public async cleanup() {
     for (const page of this.pages) {
       await page.close();

--- a/e2e-tests/tests/basic.spec.ts
+++ b/e2e-tests/tests/basic.spec.ts
@@ -20,31 +20,27 @@ test.afterAll(async () => {
 
 test.describe("Empirica in single player mode", () => {
   test("Empty experiemnt page loads successfully", async ({ browser }) => {
-    const experimentPage = new ExperimentPage({
+    const experimentPage = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });
 
     await experimentPage.open();
-
-    await Promise.all([experimentPage.close()]);
   });
 
   test("Bathes page loads successfully", async ({ browser }) => {
-    const batchesAdminPage = new BatchesAdminPage({
+    const batchesAdminPage = testFactory.createPage(BatchesAdminPage, {
       browser,
       baseUrl,
     });
 
     await batchesAdminPage.open();
-
-    await Promise.all([batchesAdminPage.close()]);
   });
 
   test("creates batch with 1 game with one player, into view, player passes through the game", async ({
     browser,
   }) => {
-    const batchesPage = new BatchesAdminPage({
+    const batchesPage = testFactory.createPage(BatchesAdminPage, {
       browser,
       baseUrl,
     });
@@ -65,7 +61,7 @@ test.describe("Empirica in single player mode", () => {
 
     await batchesPage.startGame();
 
-    const experimentPage = new ExperimentPage({
+    const experimentPage = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });
@@ -98,7 +94,5 @@ test.describe("Empirica in single player mode", () => {
     });
 
     await experimentPage.checkIfFinished();
-
-    await Promise.all([experimentPage.close(), batchesPage.close()]);
   });
 });

--- a/e2e-tests/tests/basic.spec.ts
+++ b/e2e-tests/tests/basic.spec.ts
@@ -26,6 +26,8 @@ test.describe("Empirica in single player mode", () => {
     });
 
     await experimentPage.open();
+
+    await Promise.all([experimentPage.close()]);
   });
 
   test("Bathes page loads successfully", async ({ browser }) => {
@@ -35,6 +37,8 @@ test.describe("Empirica in single player mode", () => {
     });
 
     await batchesAdminPage.open();
+
+    await Promise.all([batchesAdminPage.close()]);
   });
 
   test("creates batch with 1 game with one player, into view, player passes through the game", async ({
@@ -94,5 +98,7 @@ test.describe("Empirica in single player mode", () => {
     });
 
     await experimentPage.checkIfFinished();
+
+    await Promise.all([experimentPage.close(), batchesPage.close()]);
   });
 });

--- a/e2e-tests/tests/lobby-timeouts-individual.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-individual.spec.ts
@@ -23,7 +23,7 @@ test.afterAll(async () => {
 });
 
 test.describe("Lobby timeouts in Empirica", () => {
-  test.skip("create configuration with a individual lobby timeout", async ({
+  test("create configuration with a individual lobby timeout", async ({
     browser,
   }) => {
     const batchesPage = new BatchesAdminPage({

--- a/e2e-tests/tests/lobby-timeouts-individual.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-individual.spec.ts
@@ -90,5 +90,11 @@ test.describe("Lobby timeouts in Empirica", () => {
     });
 
     await player1Page.checkIfFinished();
+
+    await Promise.all([
+      player1Page.close(),
+      batchesPage.close(),
+      lobbiesPage.close(),
+    ]);
   });
 });

--- a/e2e-tests/tests/lobby-timeouts-individual.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-individual.spec.ts
@@ -64,7 +64,7 @@ test.describe("Lobby timeouts in Empirica", () => {
 
     await batchesPage.startGame();
 
-    const player1Page = new ExperimentPage({
+    const player1Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });
@@ -90,11 +90,5 @@ test.describe("Lobby timeouts in Empirica", () => {
     });
 
     await player1Page.checkIfFinished();
-
-    await Promise.all([
-      player1Page.close(),
-      batchesPage.close(),
-      lobbiesPage.close(),
-    ]);
   });
 });

--- a/e2e-tests/tests/lobby-timeouts-individual.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-individual.spec.ts
@@ -10,7 +10,6 @@ import { createPlayer } from "../utils/playerUtils";
 import { baseUrl } from "../setup/setupConstants";
 import LobbiesAdminPage, {
   LobbyTimeoutKind,
-  LobbyTimeoutStrategy,
 } from "../page-objects/admin/LobbiesAdminPage";
 
 const testFactory = new EmpiricaTestFactory();
@@ -24,7 +23,7 @@ test.afterAll(async () => {
 });
 
 test.describe("Lobby timeouts in Empirica", () => {
-  test("create configuration with a individual lobby timeout", async ({
+  test.skip("create configuration with a individual lobby timeout", async ({
     browser,
   }) => {
     const batchesPage = new BatchesAdminPage({

--- a/e2e-tests/tests/lobby-timeouts-individual.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-individual.spec.ts
@@ -26,11 +26,11 @@ test.describe("Lobby timeouts in Empirica", () => {
   test("create configuration with a individual lobby timeout", async ({
     browser,
   }) => {
-    const batchesPage = new BatchesAdminPage({
+    const batchesPage = testFactory.createPage(BatchesAdminPage,{
       browser,
       baseUrl,
     });
-    const lobbiesPage = new LobbiesAdminPage({
+    const lobbiesPage = testFactory.createPage(LobbiesAdminPage,{
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
@@ -102,12 +102,5 @@ test.describe("Lobby timeouts in Empirica", () => {
     });
 
     await player1Page.checkIfFinished();
-
-    await Promise.all([
-      player1Page.close(),
-      player2Page.close(),
-      batchesPage.close(),
-      lobbiesPage.close(),
-    ]);
   });
 });

--- a/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
@@ -32,7 +32,7 @@ test.describe("Lobby timeouts in Empirica", () => {
       baseUrl,
     });
 
-    const lobbiesPage = testFactory.createPage(LobbiesAdminPage, {
+    const lobbiesPage = testFactory.createPage(LobbiesAdminPage,{
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
@@ -101,5 +101,12 @@ test.describe("Lobby timeouts in Empirica", () => {
     });
 
     await player1Page.checkIfFinished();
+
+    await Promise.all([
+      player1Page.close(),
+      player2Page.close(),
+      batchesPage.close(),
+      lobbiesPage.close(),
+    ]);
   });
 });

--- a/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-fail.spec.ts
@@ -27,11 +27,12 @@ test.describe("Lobby timeouts in Empirica", () => {
   test("create configuration with a shared lobby timeout, fail strategy", async ({
     browser,
   }) => {
-    const batchesPage = new BatchesAdminPage({
+    const batchesPage = testFactory.createPage(BatchesAdminPage, {
       browser,
       baseUrl,
     });
-    const lobbiesPage = new LobbiesAdminPage({
+
+    const lobbiesPage = testFactory.createPage(LobbiesAdminPage, {
       browser,
       baseUrl,
     });
@@ -66,12 +67,12 @@ test.describe("Lobby timeouts in Empirica", () => {
 
     await batchesPage.startGame();
 
-    const player1Page = new ExperimentPage({
+    const player1Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });
 
-    const player2Page = new ExperimentPage({
+    const player2Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
@@ -105,12 +105,5 @@ test.describe("Lobby timeouts in Empirica", () => {
     });
 
     await player1Page.checkIfFinished();
-
-    await Promise.all([
-      player1Page.close(),
-      player2Page.close(),
-      batchesPage.close(),
-      lobbiesPage.close(),
-    ]);
   });
 });

--- a/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
@@ -27,11 +27,11 @@ test.describe("Lobby timeouts in Empirica", () => {
   test("create configuration with a shared lobby timeout, ignore strategy", async ({
     browser,
   }) => {
-    const batchesPage = new BatchesAdminPage({
+    const batchesPage = testFactory.createPage(BatchesAdminPage,{
       browser,
       baseUrl,
     });
-    const lobbiesPage = new LobbiesAdminPage({
+    const lobbiesPage = testFactory.createPage(LobbiesAdminPage,{
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
@@ -66,12 +66,12 @@ test.describe("Lobby timeouts in Empirica", () => {
 
     await batchesPage.startGame();
 
-    const player1Page = new ExperimentPage({
+    const player1Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });
 
-    const player2Page = new ExperimentPage({
+    const player2Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
+++ b/e2e-tests/tests/lobby-timeouts-shared-ignore.spec.ts
@@ -105,5 +105,12 @@ test.describe("Lobby timeouts in Empirica", () => {
     });
 
     await player1Page.checkIfFinished();
+
+    await Promise.all([
+      player1Page.close(),
+      player2Page.close(),
+      batchesPage.close(),
+      lobbiesPage.close(),
+    ]);
   });
 });

--- a/e2e-tests/tests/multiplayer-one-player.spec.ts
+++ b/e2e-tests/tests/multiplayer-one-player.spec.ts
@@ -74,11 +74,5 @@ test.describe("Empirica in multi-player mode", () => {
     await player1Page.checkIfFinished();
 
     await player2Page.checkIfNoExperimentsVisible();
-
-    await Promise.all([
-      player1Page.close(),
-      player2Page.close(),
-      batchesPage.close(),
-    ]);
   });
 });

--- a/e2e-tests/tests/multiplayer-one-player.spec.ts
+++ b/e2e-tests/tests/multiplayer-one-player.spec.ts
@@ -21,7 +21,7 @@ test.describe("Empirica in multi-player mode", () => {
   test("creates batch with 1 game with one player, into view, one player finishes the game, 2nd player sees no games", async ({
     browser,
   }) => {
-    const batchesPage = new BatchesAdminPage({
+    const batchesPage = testFactory.createPage(BatchesAdminPage,{
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/multiplayer-one-player.spec.ts
+++ b/e2e-tests/tests/multiplayer-one-player.spec.ts
@@ -40,12 +40,12 @@ test.describe("Empirica in multi-player mode", () => {
 
     await batchesPage.startGame();
 
-    const player1Page = new ExperimentPage({
+    const player1Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });
 
-    const player2Page = new ExperimentPage({
+    const player2Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/multiplayer-one-player.spec.ts
+++ b/e2e-tests/tests/multiplayer-one-player.spec.ts
@@ -74,5 +74,11 @@ test.describe("Empirica in multi-player mode", () => {
     await player1Page.checkIfFinished();
 
     await player2Page.checkIfNoExperimentsVisible();
+
+    await Promise.all([
+      player1Page.close(),
+      player2Page.close(),
+      batchesPage.close(),
+    ]);
   });
 });

--- a/e2e-tests/tests/multiplayer-two-players.spec.ts
+++ b/e2e-tests/tests/multiplayer-two-players.spec.ts
@@ -92,11 +92,5 @@ test.describe("Empirica in multi-player mode", () => {
 
     await player1Page.checkIfFinished();
     await player2Page.checkIfFinished();
-
-    await Promise.all([
-      player1Page.close(),
-      player2Page.close(),
-      batchesPage.close(),
-    ]);
   });
 });

--- a/e2e-tests/tests/multiplayer-two-players.spec.ts
+++ b/e2e-tests/tests/multiplayer-two-players.spec.ts
@@ -92,5 +92,11 @@ test.describe("Empirica in multi-player mode", () => {
 
     await player1Page.checkIfFinished();
     await player2Page.checkIfFinished();
+
+    await Promise.all([
+      player1Page.close(),
+      player2Page.close(),
+      batchesPage.close(),
+    ]);
   });
 });

--- a/e2e-tests/tests/multiplayer-two-players.spec.ts
+++ b/e2e-tests/tests/multiplayer-two-players.spec.ts
@@ -43,12 +43,12 @@ test.describe("Empirica in multi-player mode", () => {
 
     await batchesPage.startGame();
 
-    const player1Page = new ExperimentPage({
+    const player1Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });
 
-    const player2Page = new ExperimentPage({
+    const player2Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/multiplayer-two-players.spec.ts
+++ b/e2e-tests/tests/multiplayer-two-players.spec.ts
@@ -22,7 +22,7 @@ test.describe("Empirica in multi-player mode", () => {
   test("creates batch with 1 game with 2 players, both players finish the game", async ({
     browser,
   }) => {
-    const batchesPage = new BatchesAdminPage({
+    const batchesPage = testFactory.createPage(BatchesAdminPage,{
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/players-assigments.spec.ts
+++ b/e2e-tests/tests/players-assigments.spec.ts
@@ -110,5 +110,11 @@ test.describe("Assignments in Empirica", () => {
     );
 
     await player1Page.checkIfFinished();
+
+    await Promise.all([
+      player1Page.close(),
+      player2Page.close(),
+      batchesPage.close(),
+    ]);
   });
 });

--- a/e2e-tests/tests/players-assigments.spec.ts
+++ b/e2e-tests/tests/players-assigments.spec.ts
@@ -43,12 +43,12 @@ test.describe("Assignments in Empirica", () => {
 
     await batchesPage.startGame();
 
-    const player1Page = new ExperimentPage({
+    const player1Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });
 
-    const player2Page = new ExperimentPage({
+    const player2Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/players-assigments.spec.ts
+++ b/e2e-tests/tests/players-assigments.spec.ts
@@ -110,11 +110,5 @@ test.describe("Assignments in Empirica", () => {
     );
 
     await player1Page.checkIfFinished();
-
-    await Promise.all([
-      player1Page.close(),
-      player2Page.close(),
-      batchesPage.close(),
-    ]);
   });
 });

--- a/e2e-tests/tests/players-assigments.spec.ts
+++ b/e2e-tests/tests/players-assigments.spec.ts
@@ -23,7 +23,7 @@ test.describe("Assignments in Empirica", () => {
   test("creates a simple batch with 2 games for solo players, 2 players are assigned to two games", async ({
     browser,
   }) => {
-    const batchesPage = new BatchesAdminPage({
+    const batchesPage = testFactory.createPage(BatchesAdminPage,{
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/players-assignments-performance.spec.ts
+++ b/e2e-tests/tests/players-assignments-performance.spec.ts
@@ -88,7 +88,5 @@ test.describe("Performance tests for Empirica", () => {
 
       await experimentPage.checkIfJellyBeansVisible();
     }
-
-    await Promise.all([batchesPage.close()]);
   });
 });

--- a/e2e-tests/tests/players-assignments-performance.spec.ts
+++ b/e2e-tests/tests/players-assignments-performance.spec.ts
@@ -48,7 +48,7 @@ test.describe("Performance tests for Empirica", () => {
   test.skip("creates batch with multiple games, all players get assigned correctly @performance", async ({
     browser,
   }) => {
-    const batchesPage = new BatchesAdminPage({
+    const batchesPage = testFactory.createPage(BatchesAdminPage,{
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/players-assignments-performance.spec.ts
+++ b/e2e-tests/tests/players-assignments-performance.spec.ts
@@ -88,5 +88,7 @@ test.describe("Performance tests for Empirica", () => {
 
       await experimentPage.checkIfJellyBeansVisible();
     }
+
+    await Promise.all([batchesPage.close()]);
   });
 });

--- a/e2e-tests/tests/players-assignments-performance.spec.ts
+++ b/e2e-tests/tests/players-assignments-performance.spec.ts
@@ -20,7 +20,7 @@ test.afterAll(async () => {
 });
 
 async function addPlayerToGame({ browser, player }) {
-  const experimentPage = new ExperimentPage({
+  const experimentPage = testFactory.createPage(ExperimentPage, {
     browser,
     baseUrl,
   });

--- a/e2e-tests/tests/players-kicked-out.spec.ts
+++ b/e2e-tests/tests/players-kicked-out.spec.ts
@@ -24,7 +24,7 @@ test.describe("Assignments in Empirica", () => {
   test.skip("creates a simple batch with 2 games for solo players, stop batch, players get kicked out", async ({
     browser,
   }) => {
-    const batchesPage = new BatchesAdminPage({
+    const batchesPage = testFactory.createPage(BatchesAdminPage,{
       browser,
       baseUrl,
     });

--- a/e2e-tests/tests/players-kicked-out.spec.ts
+++ b/e2e-tests/tests/players-kicked-out.spec.ts
@@ -83,5 +83,7 @@ test.describe("Assignments in Empirica", () => {
       batchNumber: 0,
       status: BatchStatus.Terminated,
     });
+
+    await Promise.all([batchesPage.close(), player1Page.close()]);
   });
 });

--- a/e2e-tests/tests/players-kicked-out.spec.ts
+++ b/e2e-tests/tests/players-kicked-out.spec.ts
@@ -82,7 +82,5 @@ test.describe("Assignments in Empirica", () => {
       batchNumber: 0,
       status: BatchStatus.Terminated,
     });
-
-    await Promise.all([batchesPage.close(), player1Page.close()]);
   });
 });

--- a/e2e-tests/tests/players-kicked-out.spec.ts
+++ b/e2e-tests/tests/players-kicked-out.spec.ts
@@ -33,7 +33,6 @@ test.describe("Assignments in Empirica", () => {
     const player2 = createPlayer();
     const gamesCount = 2;
     const gameMode = GamesTypeTreatment.Solo;
-    const batchNumber = 0;
 
     await batchesPage.open();
 
@@ -44,12 +43,12 @@ test.describe("Assignments in Empirica", () => {
 
     await batchesPage.startGame();
 
-    const player1Page = new ExperimentPage({
+    const player1Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });
 
-    const player2Page = new ExperimentPage({
+    const player2Page = testFactory.createPage(ExperimentPage, {
       browser,
       baseUrl,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@playwright/test": "^1.29.2",
+        "@playwright/test": "^1.28.0",
         "@types/tar": "^6.1.3",
         "tar": "^6.1.13",
         "uuid": "^9.0.0"
@@ -57,7 +57,7 @@
       "extraneous": true
     },
     "lib/@empirica/core": {
-      "version": "1.0.0-rc.24",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@empirica/tajriba": "1.0.0-rc.20",


### PR DESCRIPTION
In details:

1. Closing all the pages after the suite has been finished
2. Added destroy method to all the streams of the created Empirica process (that removes the  "EPIPE" error) 
3. Added caching for the Playwright browsers
4. Upload test results into artifacts
5. Added additional way to kill the Empirica cli using the kill command (the issue with the CLI not being killed happens on the CI only though)