### PR TITLE
enhancement: expand bufio scanner buffer size from 64kb to 2mb 

### DIFF
--- a/.changeset/export-buffer.md
+++ b/.changeset/export-buffer.md
@@ -1,0 +1,5 @@
+---
+"@empirica/core": patch
+---
+
+Expand export buffer size from 64kb to 2mb 

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -43,6 +43,8 @@ func prepare(tajfile string) ([]*Kind, error) {
 	scopeKinds := make(map[string]*Kind)
 
 	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 2048*1024)
+	scanner.Buffer(buf, 2048*1024)
 
 	for scanner.Scan() {
 		line := scanner.Text()


### PR DESCRIPTION
Expand bufio scanner buffer size from 64kb to 2mb to accommodate longer fields in data exports. Addresses #565. 

First PR, so please let me know if I'm missing anything. Thanks! 