### PR TITLE
fix: handle null timerID race condition in Stage.end()

### DIFF
--- a/.changeset/fix-stage-timer-race-condition.md
+++ b/.changeset/fix-stage-timer-race-condition.md
@@ -1,0 +1,9 @@
+---
+"@empirica/core": patch
+---
+
+Fix race condition in Stage.end() when timerID is null
+
+Fixed a race condition bug where Stage.end() would crash with "Error caught in Stage.end: possibly from addTransitions() due to null timerID" when multiple players (10+) are playing simultaneously. The issue occurred when Stage.end() was called before the stage initialization finalizer completed, resulting in a null timerID being passed to addTransitions(). The fix adds proper null checking and graceful error handling, preventing premature game termination while maintaining normal functionality when timerID is available.
+
+Fixes: https://github.com/empiricaly/empirica/issues/595 

--- a/lib/@empirica/core/src/admin/classic/models.ts
+++ b/lib/@empirica/core/src/admin/classic/models.ts
@@ -1022,11 +1022,25 @@ export class Stage extends GameOwned {
     this.set("status", status);
     this.set("endedReason", reason);
 
+    // Safely get timerID and handle case where it might be null/undefined
+    const timerIDValue = this.get("timerID");
+
+    // Only proceed with transition if timerID is available
+    if (!timerIDValue) {
+      debug(
+        `stage end: timerID not available for stage ${this.id}, skipping transition`
+      );
+      return;
+    }
+
+    // Parse timerID as string since we know it's not null
+    const timerID = isString(timerIDValue);
+
     this.addTransitions([
       {
         from: State.Running,
         to: State.Ended,
-        nodeID: this.get("timerID") as string,
+        nodeID: timerID,
         cause: reason,
       },
     ])

--- a/lib/@empirica/core/src/admin/classic/stage_timer_fix_test.ts
+++ b/lib/@empirica/core/src/admin/classic/stage_timer_fix_test.ts
@@ -1,0 +1,68 @@
+import test from "ava";
+import { debug } from "console";
+import sinon from "sinon";
+import { z } from "zod";
+
+// Test the logic that we added to handle null timerID
+test("timerID null check logic works correctly", (t) => {
+  // Mock the debug function to capture its calls
+  const debugSpy = sinon.spy(console, "debug");
+
+  // Simulate the logic we added to Stage.end()
+  function simulateStageEndLogic(timerID: any, stageId: string): boolean {
+    if (!timerID) {
+      debug(
+        `stage end: timerID not available for stage ${stageId}, skipping transition`
+      );
+      return false; // Skip transition
+    }
+    return true; // Proceed with transition
+  }
+
+  // Test case 1: null timerID should skip transition
+  const result1 = simulateStageEndLogic(null, "stage123");
+  t.false(result1);
+  t.true(
+    debugSpy.calledWith(
+      "stage end: timerID not available for stage stage123, skipping transition"
+    )
+  );
+
+  // Test case 2: undefined timerID should skip transition
+  debugSpy.resetHistory();
+  const result2 = simulateStageEndLogic(undefined, "stage456");
+  t.false(result2);
+  t.true(
+    debugSpy.calledWith(
+      "stage end: timerID not available for stage stage456, skipping transition"
+    )
+  );
+
+  // Test case 3: empty string should skip transition
+  debugSpy.resetHistory();
+  const result3 = simulateStageEndLogic("", "stage789");
+  t.false(result3);
+  t.true(
+    debugSpy.calledWith(
+      "stage end: timerID not available for stage stage789, skipping transition"
+    )
+  );
+
+  // Test case 4: valid timerID should proceed with transition
+  debugSpy.resetHistory();
+  const result4 = simulateStageEndLogic("timer123", "stage999");
+  t.true(result4);
+  t.false(debugSpy.called);
+
+  debugSpy.restore();
+});
+
+test("isString function behavior with null values", (t) => {
+  const isString = z.string().parse;
+
+  // Test that isString throws on null/undefined (which is why we need the null check first)
+  t.throws(() => isString(null));
+  t.throws(() => isString(undefined));
+  t.notThrows(() => isString("")); // Empty string is valid
+  t.notThrows(() => isString("valid-timer-id"));
+});


### PR DESCRIPTION
Fixed race condition where Stage.end() would crash when called before stage initialization completed, causing null timerID to be passed to addTransitions(). This occurred under high load (10+ simultaneous players) and would end games prematurely.

Changes:
- Add null check for timerID before calling addTransitions()
- Graceful error handling with debug logging when timerID unavailable
- Maintain backward compatibility for normal operation

Fixes #595